### PR TITLE
Update scipy to 1.5.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,7 @@
 from io import BytesIO
-import os, io, math, random
+import os, io
 from functools import wraps
 from typing import Dict, Tuple, List, Union, Set
-import array
-import uuid
 from datetime import datetime
 
 import settings
@@ -19,23 +17,7 @@ import googleapiclient.discovery
 from googleapiclient.http import MediaIoBaseDownload
 import google_auth_oauthlib.flow
 
-# working with matlab (.mat) files, especially images
-import h5py
-from scipy.io import loadmat
-from PIL import Image
-from PIL import ImageFilter
-from PIL import ImageChops
-import piexif
-import numpy as np
-
-# for doing preprocessing on tracks array
-import pandas as pd;
-
-# for generating pb files
-# import pbCsv_pb2
-import pbCurveList_pb2
-
-# for saving structured exif data
+# various json manipulation
 import json
 
 SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1
 google-oauth==1.0.1
 gunicorn==20.0.4
-h5py==2.10.0
 httplib2==0.15.0
 idna==2.8
 isort==4.3.21
@@ -21,11 +20,7 @@ Jinja2==2.10.3
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
-numpy==1.18.1
 oauthlib==3.1.0
-pandas==1.2.3
-piexif==1.1.3
-Pillow==7.0.0
 protobuf==3.14.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.7
@@ -38,7 +33,6 @@ pytz==2021.1
 requests==2.22.0
 requests-oauthlib==1.3.0
 rsa==4.0
-scipy==1.5.0
 six==1.13.0
 typed-ast==1.4.0
 uritemplate==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pytz==2021.1
 requests==2.22.0
 requests-oauthlib==1.3.0
 rsa==4.0
-scipy==1.4.1
+scipy==1.5.0
 six==1.13.0
 typed-ast==1.4.0
 uritemplate==3.0.1


### PR DESCRIPTION
Updates scipy to 1.5.0 so it can be built on debian with gfortran10. I'm trying to docker-ize this app and this is required for a successful install.

Please check that these changes don't affect the functionality of Loon.

See here: https://github.com/scipy/scipy/issues/11611